### PR TITLE
Solved infinite fall issue.

### DIFF
--- a/game/src/Levels/Level1.tscn
+++ b/game/src/Levels/Level1.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://assets/tilesets/prototype.tres" type="TileSet" id=1]
 [ext_resource path="res://assets/tilesets/valley.tres" type="TileSet" id=2]
 [ext_resource path="res://src/Objects/HookTarget.tscn" type="PackedScene" id=3]
-[ext_resource path="res://src/Objects/Portal.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/Objects/Checkpoint.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/Objects/Portal.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/Objects/DeathZone.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/Objects/DeathZone.gd" type="Script" id=7]
 
 [node name="Level" type="Node2D"]
 
@@ -101,9 +104,16 @@ gravity_point = true
 [node name="0" type="Node2D" parent="Checkpoints"]
 position = Vector2( 308.292, 985.772 )
 
-[node name="Exit" parent="." instance=ExtResource( 4 )]
+[node name="Checkpoint" parent="Checkpoints" instance=ExtResource( 4 )]
+position = Vector2( 477.926, 1107.13 )
+
+[node name="Exit" parent="." instance=ExtResource( 5 )]
 position = Vector2( 184, 1081.39 )
 
-[node name="Exit2" parent="." instance=ExtResource( 4 )]
+[node name="Exit2" parent="." instance=ExtResource( 5 )]
 position = Vector2( 26256, 1648 )
 next_level_file_path = "res://src/Levels/Level2.tscn"
+
+[node name="DeathZone" parent="." instance=ExtResource( 6 )]
+script = ExtResource( 7 )
+[connection signal="body_entered" from="DeathZone" to="DeathZone" method="_on_DeathZone_body_entered"]

--- a/game/src/Main/Game.tscn
+++ b/game/src/Main/Game.tscn
@@ -5,8 +5,8 @@
 [ext_resource path="res://src/UI/debug/DebugDock.gd" type="Script" id=3]
 [ext_resource path="res://src/UI/debug/DebugPanel.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/UI/LoadingTransition.tscn" type="PackedScene" id=5]
-[ext_resource path="res://src/Player/Player.tscn" type="PackedScene" id=8]
-[ext_resource path="res://src/Levels/SkyParallaxBackground.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/Player/Player.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/Levels/SkyParallaxBackground.tscn" type="PackedScene" id=7]
 
 [node name="Game" type="Node"]
 script = ExtResource( 1 )
@@ -49,8 +49,8 @@ properties = PoolStringArray( "_state_name" )
 
 [node name="Transition" parent="UI" instance=ExtResource( 5 )]
 
-[node name="Player" parent="." instance=ExtResource( 8 )]
+[node name="Player" parent="." instance=ExtResource( 6 )]
 
-[node name="SkyParallaxBackground" parent="." instance=ExtResource( 9 )]
+[node name="SkyParallaxBackground" parent="." instance=ExtResource( 7 )]
 
 [editable path="Player"]

--- a/game/src/Objects/DeathZone.gd
+++ b/game/src/Objects/DeathZone.gd
@@ -1,0 +1,18 @@
+extends Area2D
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass
+
+
+func _on_DeathZone_body_entered(body):
+	if body is KinematicBody2D:
+		body._on_Body_Enter_Death_Zone()

--- a/game/src/Objects/DeathZone.tscn
+++ b/game/src/Objects/DeathZone.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 3056.09, 10 )
+
+[node name="Area2D" type="Area2D"]
+position = Vector2( 22239.7, 2514.46 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )

--- a/game/src/Player/Player.gd
+++ b/game/src/Player/Player.gd
@@ -59,6 +59,9 @@ func get_collider() -> CollisionShape2D:
 func _on_Player_health_depleted() -> void:
 	state_machine.transition_to("Die", {last_checkpoint = last_checkpoint})
 
+func _on_Body_Enter_Death_Zone() -> void:
+	state_machine.transition_to("Die", {last_checkpoint = last_checkpoint})	
+
 
 func _on_Events_checkpoint_visited(checkpoint_name: String) -> void:
 	last_checkpoint = LevelLoader._level.get_node("Checkpoints/%s" % checkpoint_name)


### PR DESCRIPTION
Add Checkpoint to Lv 1.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #187 #185 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Added a Checkpoint on Level 1, which prevents the game from crashing if you hook multiple times to a single target. I've also created a new Death Zone scene which kills the player instantly to avoid falling endlessly
